### PR TITLE
Skip expenses that have already been written.

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,18 +21,15 @@ func NewObsidianParserCommand() *cobra.Command {
 				return
 			}
 
-			formattedExpenses, err := obsidian.FormatExpensesForObsidian(expenses)
-
-			if err != nil {
-				fmt.Println("Formatting expenses failed", err)
-				return
-			}
-
 			// TODO:could be improved to decide code flow based on state of the program instead of file path
 			if len(outputFilePath) > 0 {
-				obsidian.WriteToObsidianVault(formattedExpenses, outputFilePath)
+				err = obsidian.WriteToObsidianVault(expenses, outputFilePath)
+
+				if err != nil {
+					fmt.Println("errors while writing to Obsidian: ", err)
+				}
 			} else {
-				obsidian.WriteToConsole(formattedExpenses)
+				obsidian.WriteToConsole(expenses)
 			}
 		},
 	}

--- a/pkg/obsidian/obsidian.go
+++ b/pkg/obsidian/obsidian.go
@@ -3,21 +3,16 @@ package obsidian
 
 import (
 	"fmt"
+	"io"
+	"math"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/kartikx/obsidian-finances-parser/pkg/models"
 )
 
-func FormatExpensesForObsidian(expenses []*models.Expense) ([]string, error) {
-	formattedExpenses := make([]string, 0, len(expenses))
-
-	for _, expense := range expenses {
-		formattedExpense := formatExpenseForObsidian(expense)
-		formattedExpenses = append(formattedExpenses, formattedExpense)
-	}
-
-	return formattedExpenses, nil
-}
+var dateAttributeInFormattedExpenseRegex = regexp.MustCompile(`\(date::(.*?)\)`)
 
 func formatExpenseForObsidian(expense *models.Expense) string {
 	categories := ""
@@ -41,7 +36,7 @@ func formatExpenseForObsidian(expense *models.Expense) string {
 }
 
 // TODO Rename this function and file.
-func WriteToObsidianVault(formattedExpenses []string, outputFilePath string) error {
+func WriteToObsidianVault(expenses []*models.Expense, outputFilePath string) error {
 	fmt.Println("Writing to Obsidian Vault")
 
 	if len(outputFilePath) == 0 {
@@ -56,8 +51,42 @@ func WriteToObsidianVault(formattedExpenses []string, outputFilePath string) err
 
 	defer file.Close()
 
-	// TODO Appends should not write expenses that are already present. Will need to seek to figure this out.
-	for _, formattedExpense := range formattedExpenses {
+	fileInfo, err := os.Stat(outputFilePath)
+	if err != nil {
+		return err
+	}
+
+	// Every expense will definitely be in the future from this date.
+	lastWrittenExpenseDate := "2023-01-01"
+
+	// If expenses are already present in this file, find the last written expense.
+	if fileSize := fileInfo.Size(); fileSize > 0 {
+		lastWrittenExpense, err := findLastExpenseInFile(file, fileSize)
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Last already written expense is: ", lastWrittenExpense)
+
+		lastWrittenExpenseDate, err = getDateFromFormattedExpense(lastWrittenExpense)
+
+		if err != nil {
+			lastWrittenExpenseDate = "2023-01-01"
+			fmt.Printf("Unable to parse date from last line: \"%s\". Using default date \"%s\" instead",
+				lastWrittenExpense, lastWrittenExpenseDate)
+		}
+	}
+
+	for _, expense := range expenses {
+		// Skip forward to find the first transaction that has not been written, based on the date.
+		// TODO @kartikx This might skip some transactions on the last date, which differs only in the timestamp.
+		if lastWrittenExpenseDate >= expense.Date {
+			continue
+		}
+
+		formattedExpense := formatExpenseForObsidian(expense)
+
 		_, err = file.WriteString(formattedExpense + "\n")
 
 		if err != nil {
@@ -69,8 +98,54 @@ func WriteToObsidianVault(formattedExpenses []string, outputFilePath string) err
 	return nil
 }
 
-func WriteToConsole(formattedExpenses []string) {
-	for _, formattedExpense := range formattedExpenses {
-		fmt.Println(formattedExpense)
+func WriteToConsole(expenses []*models.Expense) {
+	for _, expense := range expenses {
+		fmt.Println(formatExpenseForObsidian(expense))
 	}
+}
+
+func findLastExpenseInFile(file *os.File, fileSize int64) (string, error) {
+	lastExpense := ""
+
+	// An expense line should be 300 bytes at maximum.
+	// Seeking 512 bytes from the end should provide at least one expense.
+	bytesToSeek := math.Min(512, float64(fileSize))
+
+	_, err := file.Seek(int64(-bytesToSeek), io.SeekEnd)
+
+	if err != nil {
+		return "", err
+	}
+
+	buffer := make([]byte, 512)
+
+	bytesRead, err := file.Read(buffer)
+
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(string(buffer[:bytesRead]), "\n")
+
+	// Skip trailing new lines.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+
+		if len(line) > 0 {
+			lastExpense = line
+			break
+		}
+	}
+
+	return lastExpense, nil
+}
+
+func getDateFromFormattedExpense(formattedExpense string) (string, error) {
+	matches := dateAttributeInFormattedExpenseRegex.FindStringSubmatch(formattedExpense)
+
+	if matches == nil || len(matches) < 2 {
+		return "", fmt.Errorf("no date found in expense: %s", formattedExpense)
+	}
+
+	return matches[1], nil
 }


### PR DESCRIPTION
Currently, Obsidian Writer simply appends all transactions parsed from the statement file to the output file. This leads to duplicate transactions if we write to the same output file in a rolling fashion.

For example, the invocation of Obsidian Finances Parser on 04/02 and 10/02 with statements generated on those dates, would lead to duplicate entries for transactions from 01/02 - 04/02.

This PR resolves this issue by skipping transactions based on the date. It is still possible that transactions on the edges might be missed, for example the statement passed on 10/02 might contain some additional transactions on 04/02. This can be handled using Time as well as Date. This has been noted as a TODO.